### PR TITLE
[notyet] Alternate approach: throttle pollOperation requests to Google

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 gpalloc {
-  projectMonitorPollInterval = 5 seconds
+  projectMonitorPollInterval = 20 seconds
   abandonmentTime = 2 hours
   abandonmentSweepInterval = 10 minutes
   minimumFreeProjects = 5
@@ -7,6 +7,7 @@ gpalloc {
   #GCP quota is one CreateProject operation per second.
   #https://cloud.google.com/resource-manager/docs/limits
   projectsPerSecondThrottle = 1
+  opsPerSecondThrottle = 5
 }
 
 liquibase {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/GPAllocConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/GPAllocConfig.scala
@@ -9,5 +9,6 @@ case class GPAllocConfig(
                           abandonmentSweepInterval: FiniteDuration,
                           minimumFreeProjects: Int,
                           projectsPerSecondThrottle: Int,
+                          opsPerSecondThrottle: Int,
                           projectPrefix: String
                         )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/config.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/config.scala
@@ -24,6 +24,7 @@ package object config {
       config.as[FiniteDuration]("abandonmentSweepInterval"),
       config.as[Int]("minimumFreeProjects"),
       config.as[Int]("projectsPerSecondThrottle"),
+      config.as[Int]("opsPerSecondThrottle"),
       config.as[String]("projectPrefix")
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
@@ -4,8 +4,12 @@ import java.io.{PrintWriter, StringWriter}
 
 import akka.actor.Status.Failure
 import akka.actor.{Actor, Cancellable, Props}
+import akka.contrib.throttle.TimerBasedThrottler
+import akka.contrib.throttle.Throttler.{RateInt, SetTarget}
 import akka.pattern._
+import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.gpalloc.config.GPAllocConfig
 import org.broadinstitute.dsde.workbench.gpalloc.dao.{GoogleDAO, HttpGoogleBillingDAO}
 import org.broadinstitute.dsde.workbench.gpalloc.db.{ActiveOperationRecord, DataAccess, DbReference}
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
@@ -26,14 +30,17 @@ object ProjectCreationMonitor {
   case class PollForStatus(status: BillingProjectStatus) extends ProjectCreationMonitorMessage
   case class ScheduleNextPoll(status: BillingProjectStatus) extends ProjectCreationMonitorMessage
   case class Fail(failedOps: Seq[ActiveOperationRecord]) extends ProjectCreationMonitorMessage
+
+  case class GoogleThrottleOp(googleOp: ActiveOperationRecord) extends ProjectCreationMonitorMessage
+
   case object Success extends ProjectCreationMonitorMessage
 
   def props(projectName: String,
             billingAccount: String,
             dbRef: DbReference,
             googleDAO: GoogleDAO,
-            pollInterval: FiniteDuration): Props = {
-    Props(new ProjectCreationMonitor(projectName, billingAccount, dbRef, googleDAO, pollInterval))
+            gpAllocConfig: GPAllocConfig): Props = {
+    Props(new ProjectCreationMonitor(projectName, billingAccount, dbRef, googleDAO, gpAllocConfig))
   }
 }
 
@@ -41,11 +48,16 @@ class ProjectCreationMonitor(projectName: String,
                              billingAccount: String,
                              dbRef: DbReference,
                              googleDAO: GoogleDAO,
-                             pollInterval: FiniteDuration)
+                             gpAllocConfig: GPAllocConfig)
   extends Actor
   with LazyLogging {
 
   import context._
+
+  //yes this is deprecated. no i'm not going to move to akka streams
+  //this is for GCP ratelimit, which is 10 do-things-to-projects ops per second
+  val throttler = system.actorOf(Props(classOf[TimerBasedThrottler], gpAllocConfig.opsPerSecondThrottle msgsPer 1.second))
+  throttler ! SetTarget(Some(self))
 
   override def receive: PartialFunction[Any, Unit] = {
     case WakeUp =>
@@ -58,6 +70,10 @@ class ProjectCreationMonitor(projectName: String,
       completeSetup pipeTo self
     case PollForStatus(status) =>
       pollForStatus(status) pipeTo self
+
+    //special message we use to throttle ourselves
+    case GoogleThrottleOp(googleOp) =>
+      googleThrottleOp(googleOp) pipeTo sender
 
     case ScheduleNextPoll(status) => scheduleNextPoll(status)
 
@@ -78,7 +94,7 @@ class ProjectCreationMonitor(projectName: String,
   }
 
   def scheduleNextPoll(status: BillingProjectStatus): Unit = {
-    context.system.scheduler.scheduleOnce(pollInterval, self, PollForStatus(status))
+    context.system.scheduler.scheduleOnce(gpAllocConfig.projectMonitorPollInterval, self, PollForStatus(status))
   }
 
   def resumeInflightProject: Future[ProjectCreationMonitorMessage] = {
@@ -125,13 +141,17 @@ class ProjectCreationMonitor(projectName: String,
 
   //checks Google for status of active operations and figures out what next
   def pollForStatus(status: BillingProjectStatus): Future[ProjectCreationMonitorMessage] = {
+    //timeout for self ? GoogleThrottleOp
+    implicit val timeout = Timeout(5 seconds)
+
     logger.info(s"ProjectCreationMonitor.pollForStatus $projectName $status")
     val updatedOpsF = for {
       //get ops in progress
       activeOpMap <- dbRef.inTransaction { da => da.operationQuery.getActiveOperationsByType(projectName) }
       activeCurrentStatusOps = activeOpMap.getOrElse(status, Seq())
-      //ask google
-      updatedOps <- Future.traverse(activeCurrentStatusOps.filter(!_.done)) { op => googleDAO.pollOperation(op) }
+      //ask google, but throttle ourselves
+      updatedOpsAny <- Future.traverse(activeCurrentStatusOps.filter(!_.done)) { op => throttler ? GoogleThrottleOp(op) }
+      updatedOps = updatedOpsAny.map(_.asInstanceOf[ActiveOperationRecord])
       //update the db with new op status
       _ <- dbRef.inTransaction { da => da.operationQuery.updateOperations(updatedOps) }
     } yield {
@@ -152,6 +172,10 @@ class ProjectCreationMonitor(projectName: String,
         ScheduleNextPoll(status)
       }
     }
+  }
+
+  def googleThrottleOp(op: ActiveOperationRecord): Future[ActiveOperationRecord] = {
+    googleDAO.pollOperation(op)
   }
 
   def getNextStatusMessage(status: BillingProjectStatus.BillingProjectStatus): ProjectCreationMonitorMessage = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
@@ -87,7 +87,7 @@ class ProjectCreationSupervisor(billingAccount: String, dbRef: DbReference, goog
 
   def createChildActor(projectName: String): ActorRef = {
     //use context.actorOf so we create children that will be killed if we get PoisonPilled
-    context.actorOf(ProjectCreationMonitor.props(projectName, billingAccount, dbRef, googleDAO, gpAllocConfig.projectMonitorPollInterval), monitorName(projectName))
+    context.actorOf(ProjectCreationMonitor.props(projectName, billingAccount, dbRef, googleDAO, gpAllocConfig), monitorName(projectName))
   }
 
   //TODO: hook this up. drop the database, optionally delete the projects

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -17,6 +17,7 @@ gpalloc {
   #GCP quota is one CreateProject operation per second.
   #https://cloud.google.com/resource-manager/docs/limits
   projectsPerSecondThrottle = 1
+  opsPerSecondThrottle = 5
 }
 
 mysql {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
@@ -27,6 +27,8 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
 
   import profile.api._
 
+  val tenMillisPollIntervalConf = gpAllocConfig.copy(projectMonitorPollInterval = 10 millis)
+
   def withSupervisor[T](gDAO: GoogleDAO, gpAllocConfig: GPAllocConfig = gpAllocConfig)(op: TestActorRef[TestProjectCreationSupervisor] => T): T = {
     val monitorRef = TestActorRef[TestProjectCreationSupervisor](TestProjectCreationSupervisor.props("testBillingAccount", dbRef, gDAO, gpAllocConfig, this))
 
@@ -51,7 +53,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
       }
 
       //did the monitor actor call the right things in google?
-      val longer = Timeout(Span(500, Milliseconds)) //150ms isn't enough to progress through the actor states
+      val longer = Timeout(Span(1000, Milliseconds)) //150ms isn't enough to progress through the actor states
       eventually(longer) {
         mockGoogleDAO.createdProjects should contain(newProjectName)
       }
@@ -118,7 +120,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
 
   "ProjectCreationMonitor" should "createNewProject" in isolatedDbTest {
     val mockGoogleDAO = new MockGoogleDAO()
-    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, 10 millis)).underlyingActor
+    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, tenMillisPollIntervalConf)).underlyingActor
 
     //tell the monitor to create its project
     monitor.createNewProject.futureValue shouldBe PollForStatus(CreatingProject)
@@ -140,7 +142,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
 
   it should "enableServices" in isolatedDbTest {
     val mockGoogleDAO = new MockGoogleDAO()
-    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, 10 millis)).underlyingActor
+    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, tenMillisPollIntervalConf)).underlyingActor
 
     //pretend we've already created the project
     val createdOp = freshOpRecord(newProjectName).copy(done=true)
@@ -170,7 +172,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
 
   it should "completeSetup" in isolatedDbTest {
     val mockGoogleDAO = new MockGoogleDAO()
-    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, 10 millis)).underlyingActor
+    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, tenMillisPollIntervalConf)).underlyingActor
 
     //pretend we've already created the project and enabled services
     val createdOp = freshOpRecord(newProjectName).copy(done=true)
@@ -189,7 +191,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
 
   it should "poll for active operations" in isolatedDbTest {
     val mockGoogleDAO = new MockGoogleDAO()
-    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, 10 millis)).underlyingActor
+    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, mockGoogleDAO, tenMillisPollIntervalConf)).underlyingActor
 
     //pretend we've already created the project
     val createdOp = freshOpRecord(newProjectName).copy(done=true)
@@ -207,7 +209,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
   it should "behave when google says the operation errored" in isolatedDbTest {
     val errorGoogleDAO = new MockGoogleDAO(operationsReturnError = true)
 
-    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, errorGoogleDAO, 10 millis)).underlyingActor
+    val monitor = TestActorRef[ProjectCreationMonitor](ProjectCreationMonitor.props(newProjectName, testBillingAccount, dbRef, errorGoogleDAO, tenMillisPollIntervalConf)).underlyingActor
 
     //pretend we've already created the project but not polled it yet
     val createdOp = freshOpRecord(newProjectName)


### PR DESCRIPTION
Instead of catching 429 Too Many Requests and retrying later (as in #37), we aim to be a bit better behaved and be less spammy in the first place.