### PR TITLE
handle failures by deleting the project and kicking off a new one

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/Boot.scala
@@ -51,6 +51,7 @@ object Boot extends App with LazyLogging {
       gpAllocConfig.opsThrottle,
       gpAllocConfig.opsThrottlePerDuration)
 
+    ProjectCreationSupervisor.gpAllocConfig = gpAllocConfig
     val projectCreationSupervisor = system.actorOf(
       ProjectCreationSupervisor.props(
         defaultBillingAccount,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/Boot.scala
@@ -51,7 +51,6 @@ object Boot extends App with LazyLogging {
       gpAllocConfig.opsThrottle,
       gpAllocConfig.opsThrottlePerDuration)
 
-    ProjectCreationSupervisor.gpAllocConfig = gpAllocConfig
     val projectCreationSupervisor = system.actorOf(
       ProjectCreationSupervisor.props(
         defaultBillingAccount,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.workbench.gpalloc.db.{ActiveOperationRecord, Data
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus._
 import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationMonitor._
+import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.ProjectMonitoringFailed
 import org.broadinstitute.dsde.workbench.gpalloc.util.Throttler
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import slick.dbio.DBIO
@@ -39,6 +40,8 @@ object ProjectCreationMonitor {
     Props(new ProjectCreationMonitor(projectName, billingAccountId, dbRef, googleDAO, gpAllocConfig))
   }
 }
+
+class MonitorFailedException(val projectName: String) extends RuntimeException {}
 
 class ProjectCreationMonitor(projectName: String,
                              billingAccountId: String,
@@ -68,6 +71,7 @@ class ProjectCreationMonitor(projectName: String,
     //stop because google said an operation failed
     case Fail(failedOps) =>
       logger.error(s"Creation of new project $projectName failed. These opids died: ${failedOps.map(op => s"id: ${op.operationId}, error: ${op.errorMessage}").mkString(", ")}")
+      throw new MonitorFailedException(projectName) //throw to supervisor
       cleanupOnError()
       stop(self)
 
@@ -76,6 +80,7 @@ class ProjectCreationMonitor(projectName: String,
       val stackTrace = new StringWriter
       throwable.printStackTrace(new PrintWriter(new StringWriter))
       logger.error(s"Creation of new project $projectName failed because of an exception: ${throwable.getMessage} \n${stackTrace.toString}")
+      throw new MonitorFailedException(projectName) //throw to supervisor
       cleanupOnError()
       stop(self)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
@@ -71,18 +71,16 @@ class ProjectCreationMonitor(projectName: String,
     //stop because google said an operation failed
     case Fail(failedOps) =>
       logger.error(s"Creation of new project $projectName failed. These opids died: ${failedOps.map(op => s"id: ${op.operationId}, error: ${op.errorMessage}").mkString(", ")}")
-      throw new MonitorFailedException(projectName) //throw to supervisor
       cleanupOnError()
-      stop(self)
+      throw new MonitorFailedException(projectName) //throw to supervisor. should be the last thing because it breaks control flow!
 
     //stop because something (probably google polling) throw an exception
     case Failure(throwable) =>
       val stackTrace = new StringWriter
       throwable.printStackTrace(new PrintWriter(new StringWriter))
       logger.error(s"Creation of new project $projectName failed because of an exception: ${throwable.getMessage} \n${stackTrace.toString}")
-      throw new MonitorFailedException(projectName) //throw to supervisor
       cleanupOnError()
-      stop(self)
+      throw new MonitorFailedException(projectName) //throw to supervisor. should be the last thing because it breaks control flow!
   }
 
   def cleanupOnError(): Unit = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/service/GPAllocService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/service/GPAllocService.scala
@@ -197,6 +197,6 @@ class GPAllocService(protected val dbRef: DbReference,
   }
 
   def createNewGoogleProject(): Unit = {
-    projectCreationSupervisor ! RequestNewProject()
+    projectCreationSupervisor ! RequestNewProject
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/service/GPAllocService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/service/GPAllocService.scala
@@ -178,7 +178,7 @@ class GPAllocService(protected val dbRef: DbReference,
   }
 
   //create new google project if we don't have any available
-  private def maybeCreateNewProjects(): Unit = {
+  protected def maybeCreateNewProjects(): Unit = {
     dbRef.inTransaction { da =>
       for {
         free <- da.billingProjectQuery.countUnassignedAndFutureProjects
@@ -196,9 +196,7 @@ class GPAllocService(protected val dbRef: DbReference,
     }
   }
 
-  private def createNewGoogleProject(): Unit = {
-    //strip out things GCP doesn't like in project IDs: uppercase, underscores, and things that are too long
-    val sanitizedPrefix = gpAllocConfig.projectPrefix.toLowerCase.replaceAll("[^a-z0-9-]", "").take(22)
-    projectCreationSupervisor ! RequestNewProject(s"$sanitizedPrefix-${Random.alphanumeric.take(7).mkString.toLowerCase}")
+  def createNewGoogleProject(): Unit = {
+    projectCreationSupervisor ! RequestNewProject()
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/CommonTestData.scala
@@ -72,8 +72,6 @@ trait CommonTestData {
   val swaggerConfig = config.as[SwaggerConfig]("swagger")
   val gpAllocConfig = config.as[GPAllocConfig]("gpalloc")
 
-  ProjectCreationSupervisor.gpAllocConfig = gpAllocConfig
-
   def freshBillingProjectRecord(projectName: String): BillingProjectRecord = {
     BillingProjectRecord(projectName, None, BillingProjectStatus.Queued, None)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/CommonTestData.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.gpalloc.config.{GPAllocConfig, SwaggerC
 import org.broadinstitute.dsde.workbench.gpalloc.dao.MockGoogleDAO
 import org.broadinstitute.dsde.workbench.gpalloc.db.{ActiveOperationRecord, BillingProjectRecord, DbReference, DbSingleton}
 import org.broadinstitute.dsde.workbench.gpalloc.model.{AssignedProject, BillingProjectStatus}
+import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor
 import org.broadinstitute.dsde.workbench.gpalloc.service.GPAllocService
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.util.NoopActor
@@ -70,6 +71,8 @@ trait CommonTestData {
   val config = ConfigFactory.parseResources("gpalloc.conf").withFallback(ConfigFactory.load())
   val swaggerConfig = config.as[SwaggerConfig]("swagger")
   val gpAllocConfig = config.as[GPAllocConfig]("gpalloc")
+
+  ProjectCreationSupervisor.gpAllocConfig = gpAllocConfig
 
   def freshBillingProjectRecord(projectName: String): BillingProjectRecord = {
     BillingProjectRecord(projectName, None, BillingProjectStatus.Queued, None)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import org.broadinstitute.dsde.workbench.gpalloc.dao.MockGoogleDAO
 import org.broadinstitute.dsde.workbench.gpalloc.db.{BillingProjectRecord, DbReference, DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
-import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.{RequestNamedProject, RegisterGPAllocService}
+import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.{RequestNewProject, RegisterGPAllocService}
 import org.broadinstitute.dsde.workbench.gpalloc.service.{GPAllocService, GoogleProjectNotFound, NoGoogleProjectAvailable, NotYourGoogleProject}
 import org.broadinstitute.dsde.workbench.util.NoopActor
 import org.scalatest.FlatSpecLike
@@ -41,7 +41,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
+    probe.expectMsg(1 seconds, RequestNewProject)
 
     //no more unassigned projects!
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 0
@@ -52,8 +52,8 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
-    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
+    probe.expectMsg(1 seconds, RequestNewProject)
+    probe.expectMsg(1 seconds, RequestNewProject)
   }
 
   it should "create projects up to the baseline minimum number" in isolatedDbTest {
@@ -61,8 +61,8 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
-    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
+    probe.expectMsg(1 seconds, RequestNewProject)
+    probe.expectMsg(1 seconds, RequestNewProject)
   }
 
   it should "not keep creating projects indefinitely if enough creating ones are in-flight" in isolatedDbTest {
@@ -86,7 +86,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
+    probe.expectMsg(1 seconds, RequestNewProject)
 
     //give me another! no :(
     val noProjectExc = gpAlloc.requestGoogleProject(userInfo).failed.futureValue

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import org.broadinstitute.dsde.workbench.gpalloc.dao.MockGoogleDAO
 import org.broadinstitute.dsde.workbench.gpalloc.db.{BillingProjectRecord, DbReference, DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
-import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.{RequestNewProject, RegisterGPAllocService}
+import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.{RequestNamedProject, RegisterGPAllocService}
 import org.broadinstitute.dsde.workbench.gpalloc.service.{GPAllocService, GoogleProjectNotFound, NoGoogleProjectAvailable, NotYourGoogleProject}
 import org.broadinstitute.dsde.workbench.util.NoopActor
 import org.scalatest.FlatSpecLike
@@ -41,7 +41,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNewProject])
+    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
 
     //no more unassigned projects!
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 0
@@ -52,8 +52,8 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNewProject])
-    probe.expectMsgClass(1 seconds, classOf[RequestNewProject])
+    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
+    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
   }
 
   it should "create projects up to the baseline minimum number" in isolatedDbTest {
@@ -61,8 +61,8 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNewProject])
-    probe.expectMsgClass(1 seconds, classOf[RequestNewProject])
+    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
+    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
   }
 
   it should "not keep creating projects indefinitely if enough creating ones are in-flight" in isolatedDbTest {
@@ -86,7 +86,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
     //should hit the threshold and ask the supervisor to create a project
     //(but this won't really do anything because the supervisor is a fake)
-    probe.expectMsgClass(1 seconds, classOf[RequestNewProject])
+    probe.expectMsgClass(1 seconds, classOf[RequestNamedProject])
 
     //give me another! no :(
     val noProjectExc = gpAlloc.requestGoogleProject(userInfo).failed.futureValue

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/mock/MockGPAllocService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/mock/MockGPAllocService.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.workbench.gpalloc.mock
+
+import akka.actor.ActorRef
+import org.broadinstitute.dsde.workbench.gpalloc.config.{GPAllocConfig, SwaggerConfig}
+import org.broadinstitute.dsde.workbench.gpalloc.dao.GoogleDAO
+import org.broadinstitute.dsde.workbench.gpalloc.db.DbReference
+import org.broadinstitute.dsde.workbench.gpalloc.service.GPAllocService
+
+import scala.concurrent.ExecutionContext
+
+class MockGPAllocService(dbRef: DbReference,
+                         swaggerConfig: SwaggerConfig,
+                         projectCreationSupervisor: ActorRef,
+                         googleBillingDAO: GoogleDAO,
+                         gpAllocConfig: GPAllocConfig) (executionContext: ExecutionContext)
+  extends GPAllocService(
+    dbRef,
+    swaggerConfig,
+    projectCreationSupervisor,
+    googleBillingDAO,
+    gpAllocConfig) (executionContext) {
+
+
+  override def maybeCreateNewProjects(): Unit = {} //don't
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
@@ -55,7 +55,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
     val mockGoogleDAO = new MockGoogleDAO()
 
     withSupervisor(mockGoogleDAO) { supervisor =>
-      supervisor ! RequestNewProject(newProjectName)
+      supervisor ! RequestNamedProject(newProjectName)
 
       //we're now racing against the project monitor actor, so everything from here on is eventually
       eventually {
@@ -111,9 +111,9 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
     withSupervisor(mockGoogleDAO) { supervisor =>
 
       //kick off two project creates. the throttle should kick in
-      supervisor ! RequestNewProject(newProjectName)
+      supervisor ! RequestNamedProject(newProjectName)
       Thread.sleep(100) //make sure the messages are delivered in order
-      supervisor ! RequestNewProject(newProjectName2)
+      supervisor ! RequestNamedProject(newProjectName2)
 
       eventually(timeout = Timeout(Span(2, Seconds))) {
         dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName) }.get.status shouldBe CreatingProject
@@ -133,7 +133,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
     val mockGoogleDAO = new MockGoogleDAO(pollException = true)
 
     withSupervisor(mockGoogleDAO, gpAllocConfig = fasterProjectCreationConf) { supervisor =>
-      supervisor ! ProjectCreationSupervisor.RequestNewProject(newProjectName)
+      supervisor ! ProjectCreationSupervisor.RequestNamedProject(newProjectName)
 
       //this will now get into an endless loop of creating a project, google explodes, restart...
       //we'll look for one restart
@@ -233,7 +233,7 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
       val createdOp = freshOpRecord(newProjectName)
       saveProjectAndOps(newProjectName, createdOp)
 
-      supervisor ! RequestNewProject(newProjectName)
+      supervisor ! RequestNamedProject(newProjectName)
 
       expectMsgClass(1 second, classOf[Terminated])
     }


### PR DESCRIPTION
so when a project creation fails, there are a few options:
1. do nothing, forever. the project is dead-ed-ed and is never replaced
2. do nothing until the next project request happens, at which point `maybeCreateNewProjects()` may notice that we're now below our limit and create new projects to make up for the gap
3. make a new one to replace it immediately

right now, what happens is 2. this code makes it 3.