### PR TITLE
Set abandonmentTime 1 hour

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 gpalloc {
   projectMonitorPollInterval = 5 seconds
-  abandonmentTime = 2 hours
+  abandonmentTime = 1 hours
   abandonmentSweepInterval = 10 minutes
   minimumFreeProjects = 5
 


### PR DESCRIPTION
I'd like to shorten the wait to scrub bad projects. Average tests execution time are:
1: Leo ~ 40 min
2: UI ~ 25 min
3: Rawls ~ 10 min
4: Sam ~ 5 min
5: Orche ~ 5 min