### PR TITLE
Speculative fix: Restart monitor actors when they die

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.gpalloc.monitor
 
-import akka.actor.{Actor, ActorRef, PoisonPill, Props, SupervisorStrategy}
+import akka.actor.SupervisorStrategy.Restart
+import akka.actor.{Actor, ActorRef, OneForOneStrategy, PoisonPill, Props, SupervisorStrategy}
 import akka.contrib.throttle.TimerBasedThrottler
 import akka.contrib.throttle.Throttler.{RateInt, SetTarget}
 import com.typesafe.scalalogging.LazyLogging
@@ -57,8 +58,8 @@ class ProjectCreationSupervisor(billingAccount: String, dbRef: DbReference, goog
       sweepAssignedProjects()
   }
 
-  //if a project creation monitor dies, give up on it
-  override val supervisorStrategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy
+  //if a project creation monitor dies, restart it
+  override val supervisorStrategy: SupervisorStrategy = OneForOneStrategy() { case _ => Restart }
 
   val monitorNameBase = "bpmon-"
   def monitorName(bp: String) = s"$monitorNameBase$bp"


### PR DESCRIPTION
I'm speculating a series of events here:

1. An error happens during project monitoring (likely but not limited to a ratelimit)
2. This is badly handled by the actor, throwing it up to the supervisor
3. The default supervisor strategy is to kill the actor
4. The project remains stuck in a creating state, which counts for "are there enough free projects in the pipe", so GPAlloc doesn't make more projects.

This PR fixes point 3 by restarting the actor. I'm pretty sure the errors in point 2 are transient and that retrying is the right thing to do here. It won't stop the errors happening, but it'll make us more resilient to them.