### PR TITLE
give queued project creations their own status so we can count them properly

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
@@ -73,8 +73,16 @@ trait BillingProjectComponent extends GPAllocComponent {
       findBillingProject(billingProject).filter(_.status === BillingProjectStatus.Assigned.toString).result.headOption
     }
 
+    def getPendingProjects: DBIO[Seq[BillingProjectRecord]] = {
+      billingProjectQuery.filter(_.status inSetBind BillingProjectStatus.pendingStatuses.map(_.toString) ).result
+    }
+
+    def getQueuedProjects: DBIO[Seq[BillingProjectRecord]] = {
+      billingProjectQuery.filter(_.status === BillingProjectStatus.Queued.toString ).result
+    }
+
     def getCreatingProjects: DBIO[Seq[BillingProjectRecord]] = {
-      billingProjectQuery.filter(_.status inSetBind BillingProjectStatus.creatingStatuses.map(_.toString) ).result
+      billingProjectQuery.filter(_.status === BillingProjectStatus.CreatingProject.toString ).result
     }
 
     def getUnassignedProjects: DBIO[Seq[BillingProjectRecord]] = {
@@ -155,7 +163,7 @@ trait BillingProjectComponent extends GPAllocComponent {
     //This weird function allows us to ask "do we need to kick off creating any more projects right now?"
     def countUnassignedAndFutureProjects: DBIO[Int] = {
       billingProjectQuery.filter(_.status inSetBind(
-        BillingProjectStatus.creatingStatuses.map(_.toString) ++ Seq(BillingProjectStatus.Unassigned.toString)) )
+        BillingProjectStatus.pendingStatuses.map(_.toString) ++ Seq(BillingProjectStatus.Unassigned.toString)) )
         .length.result
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
@@ -89,16 +89,10 @@ trait BillingProjectComponent extends GPAllocComponent {
       findUnassignedProjects.result
     }
 
-    def saveNew(billingProject: String, status: BillingProjectStatus = BillingProjectStatus.CreatingProject): DBIO[String] = {
+    def saveNew(billingProject: String, status: BillingProjectStatus = BillingProjectStatus.Queued): DBIO[String] = {
       (billingProjectQuery += BillingProjectRecord(billingProject, None, status, None)) map { _ =>
         billingProject
       }
-    }
-
-    def saveNewProject(billingProject: String, operationRecord: ActiveOperationRecord, status: BillingProjectStatus = BillingProjectStatus.CreatingProject): DBIO[String] = {
-      DBIO.seq(
-        saveNew(billingProject, status),
-        operationQuery.saveNewOperations(Seq(operationRecord))) map { _ => billingProject }
     }
 
     def updateStatus(billingProject: String, status: BillingProjectStatus): DBIO[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/model/GPAllocModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/model/GPAllocModel.scala
@@ -12,11 +12,11 @@ import scala.language.implicitConversions
 
 object BillingProjectStatus extends Enumeration {
   type BillingProjectStatus = Value
-  val CreatingProject, Unassigned, Assigned, Deleted = Value
-  val creatingStatuses = Seq(CreatingProject)
+  val Queued, CreatingProject, Unassigned, Assigned, Deleted = Value
+  val pendingStatuses = Seq(Queued, CreatingProject) //this project is coming, someday in the future.
 
   class StatusValue(status: BillingProjectStatus) {
-    def isCreating = creatingStatuses.contains(status)
+    def isPending = pendingStatuses.contains(status)
   }
 
   implicit def enumConvert(status: BillingProjectStatus): StatusValue = new StatusValue(status)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationMonitor.scala
@@ -100,8 +100,8 @@ class ProjectCreationMonitor(projectName: String,
 
   def createNewProject: Future[ProjectCreationMonitorMessage] = {
     for {
-      // We're not using db.saveNewProject and doing two seperate transactions here because we want to get the new project record in the db ASAP.
-      _ <- dbRef.inTransaction { da => da.billingProjectQuery.saveNew(projectName, BillingProjectStatus.CreatingProject) }
+      // We're finally creating the project in Google land! Flip its status and let's go.
+      _ <- dbRef.inTransaction { da => da.billingProjectQuery.updateStatus(projectName, BillingProjectStatus.CreatingProject) }
       newOperationRec <- googleDAO.createProject(projectName, billingAccountId)
       _ <- dbRef.inTransaction { da => da.operationQuery.saveNewOperations(Seq(newOperationRec)) }
     } yield {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
@@ -95,8 +95,9 @@ class ProjectCreationSupervisor(billingAccount: String, dbRef: DbReference, goog
     //otherwise things in the throttle queue are invisible to us, and we create the wrong number of projects.
     dbRef.inTransaction { da =>
       da.billingProjectQuery.saveNew(projectName, BillingProjectStatus.Queued)
+    } flatMap { _ =>
+      addNewProjectToThrottle(projectName)
     }
-    addNewProjectToThrottle(projectName)
   }
 
   def addNewProjectToThrottle(projectName: String): Future[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectCreationSupervisor.scala
@@ -8,6 +8,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.gpalloc.config.GPAllocConfig
 import org.broadinstitute.dsde.workbench.gpalloc.dao.{GoogleDAO, HttpGoogleBillingDAO}
 import org.broadinstitute.dsde.workbench.gpalloc.db.DbReference
+import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
 import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor._
 import org.broadinstitute.dsde.workbench.gpalloc.service.GPAllocService
 import org.broadinstitute.dsde.workbench.gpalloc.util.Throttler
@@ -39,7 +40,9 @@ class ProjectCreationSupervisor(billingAccount: String, dbRef: DbReference, goog
 
   import context._
 
-  //Google throttles project creation requests separately.
+  /* As soon as a project creation request comes in, it's saved to the db and set to Queued.
+   * Then it goes into this throttle. Once it emerges from the throttle, it will actually be created.
+   */
   val projectCreationThrottler = new Throttler(context, gpAllocConfig.projectsThrottle, gpAllocConfig.projectsThrottlePerDuration, "ProjectCreation")
 
   var gpAlloc: GPAllocService = _
@@ -65,10 +68,21 @@ class ProjectCreationSupervisor(billingAccount: String, dbRef: DbReference, goog
   def monitorName(bp: String) = s"$monitorNameBase$bp"
 
   def resumeAllProjects: Future[Unit] = {
-    dbRef.inTransaction { da => da.billingProjectQuery.getCreatingProjects } map { _.foreach { bp =>
-      val newProjectMonitor = createChildActor(bp.billingProjectName)
-      newProjectMonitor ! ProjectCreationMonitor.WakeUp
-    }}
+    dbRef.inTransaction { da =>
+      for {
+        queuedProjects <- da.billingProjectQuery.getQueuedProjects
+        creatingProjects <- da.billingProjectQuery.getCreatingProjects
+      } yield {
+        //Queued projects go back in the throttle, since they never made it to Google land.
+        queuedProjects.foreach(qp => addNewProjectToThrottle(qp.billingProjectName))
+
+        //Creating projects did make it to Google land, so they get monitor actors made for them.
+        creatingProjects.foreach { cp =>
+          val newProjectMonitor = createChildActor(cp.billingProjectName)
+          newProjectMonitor ! ProjectCreationMonitor.WakeUp
+        }
+      }
+    }
   }
 
   def sweepAssignedProjects(): Unit = {
@@ -77,6 +91,16 @@ class ProjectCreationSupervisor(billingAccount: String, dbRef: DbReference, goog
   }
 
   def requestNewProject(projectName: String): Future[Unit] = {
+    //telling the db immediately means we can get an accurate handle on the number projects that are in flight.
+    //otherwise things in the throttle queue are invisible to us, and we create the wrong number of projects.
+    dbRef.inTransaction { da =>
+      da.billingProjectQuery.saveNew(projectName, BillingProjectStatus.Queued)
+    }
+    addNewProjectToThrottle(projectName)
+  }
+
+  def addNewProjectToThrottle(projectName: String): Future[Unit] = {
+    logger.info(s"Request to create $projectName goes into the throttle.")
     projectCreationThrottler.throttle( () => Future.successful(createProject(projectName)) )
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/CommonTestData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/CommonTestData.scala
@@ -72,7 +72,7 @@ trait CommonTestData {
   val gpAllocConfig = config.as[GPAllocConfig]("gpalloc")
 
   def freshBillingProjectRecord(projectName: String): BillingProjectRecord = {
-    BillingProjectRecord(projectName, None, BillingProjectStatus.CreatingProject, None)
+    BillingProjectRecord(projectName, None, BillingProjectStatus.Queued, None)
   }
 
   def assignedBillingProjectRecord(projectName: String, owner: WorkbenchEmail, ago: FiniteDuration): BillingProjectRecord = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -66,7 +66,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   }
 
   it should "not keep creating projects indefinitely if enough creating ones are in-flight" in isolatedDbTest {
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.CreatingProject) } shouldEqual newProjectName
+    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Queued) } shouldEqual newProjectName
     dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.CreatingProject) } shouldEqual newProjectName2
     val (gpAlloc, probe, _) = gpAllocService(dbRef, 2)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -30,7 +30,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
   "GPAllocService" should "request an existing google project" in isolatedDbTest {
     //add an unassigned project to find
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 1
 
     //make a service with a project creation threshold of 1 to trigger making a new one once this one is alloc'd
@@ -66,8 +66,8 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   }
 
   it should "not keep creating projects indefinitely if enough creating ones are in-flight" in isolatedDbTest {
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Queued) } shouldEqual newProjectName
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.CreatingProject) } shouldEqual newProjectName2
+    dbFutureValue { _.billingProjectQuery.saveNew(newProjectName, BillingProjectStatus.Queued) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.CreatingProject) shouldEqual newProjectName2
     val (gpAlloc, probe, _) = gpAllocService(dbRef, 2)
 
     //maybeCreateNewProjects shouldn't create projects here because we've got 2 being created
@@ -76,7 +76,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
   it should "barf when you request a google project but there are none in the pool" in isolatedDbTest {
     //make a service with a project creation threshold of 1 to trigger making a new one once this one is alloc'd
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 1
     val (gpAlloc, probe, _) = gpAllocService(dbRef, 1)
 
@@ -98,8 +98,8 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
   it should "only ask the supervisor to create a project when below the threshold" in isolatedDbTest {
     //add two unassigned projects to the pool
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) } shouldEqual newProjectName2
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) shouldEqual newProjectName2
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 2
 
     //after assigning a project, we'll have 1 left, so a threshold of 1 means we shouldn't create another
@@ -118,7 +118,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
   it should "release a project" in isolatedDbTest {
     //add one to find and assign it to the test user
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 1
     dbFutureValue { _.billingProjectQuery.assignProjectFromPool(userInfo.userEmail.value) }
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 0
@@ -139,7 +139,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
   it should "check permissions when releasing a project" in isolatedDbTest {
     //add one to find and assign it to the test user
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 1
     dbFutureValue { _.billingProjectQuery.assignProjectFromPool(userInfo.userEmail.value) }
     dbFutureValue { _.billingProjectQuery.countUnassignedProjects } shouldBe 0
@@ -165,7 +165,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
 
   it should "not let you release a project that's not assigned" in isolatedDbTest {
     //add an unassigned one
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.CreatingProject) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.CreatingProject) shouldEqual newProjectName
 
     //here we have no minimum free projects. it's okay for us to just run out
     //this is completely unrealistic but means we have to jump through fewer hoops in the test
@@ -198,9 +198,9 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   }
 
   it should "return statistics" in isolatedDbTest {
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) } shouldEqual newProjectName2
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) } shouldEqual newProjectName3
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) shouldEqual newProjectName2
+    saveProjectAndOps(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) shouldEqual newProjectName3
 
     val (gpAlloc, _, _) = gpAllocService(dbRef, 1)
     val stats = gpAlloc.dumpStats().futureValue
@@ -208,9 +208,9 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   }
 
   it should "force cleanup of all unassigned projects" in isolatedDbTest {
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) } shouldEqual newProjectName2
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) } shouldEqual newProjectName3
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) shouldEqual newProjectName2
+    saveProjectAndOps(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) shouldEqual newProjectName3
 
     val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 1)
     gpAlloc.forceCleanupAll().futureValue
@@ -221,9 +221,9 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   }
 
   it should "delete projects" in isolatedDbTest {
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) } shouldEqual newProjectName2
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) } shouldEqual newProjectName3
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) shouldEqual newProjectName2
+    saveProjectAndOps(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) shouldEqual newProjectName3
 
     val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 1)
 
@@ -244,9 +244,9 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   }
 
   it should "delete all projects" in isolatedDbTest {
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) } shouldEqual newProjectName
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) } shouldEqual newProjectName2
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) } shouldEqual newProjectName3
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) shouldEqual newProjectName2
+    saveProjectAndOps(newProjectName3, freshOpRecord(newProjectName3), BillingProjectStatus.Assigned) shouldEqual newProjectName3
 
     val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 1)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
@@ -22,7 +22,7 @@ class BillingProjectComponentSpec extends TestComponent with FlatSpecLike with C
     dbFutureValue { _.billingProjectQuery.saveNew(newProjectName2) } shouldEqual newProjectName2
 
     //look for them again
-    dbFutureValue { _.billingProjectQuery.getCreatingProjects } should contain theSameElementsAs Seq(
+    dbFutureValue { _.billingProjectQuery.getPendingProjects } should contain theSameElementsAs Seq(
       freshBillingProjectRecord(newProjectName),
       freshBillingProjectRecord(newProjectName2)
     )
@@ -93,7 +93,7 @@ class BillingProjectComponentSpec extends TestComponent with FlatSpecLike with C
 
     dbFutureValue { _.billingProjectQuery.releaseProject(newProjectName) } shouldEqual 0
 
-    dbFutureValue { _.billingProjectQuery.getCreatingProjects } should contain theSameElementsAs Seq(
+    dbFutureValue { _.billingProjectQuery.getPendingProjects } should contain theSameElementsAs Seq(
       freshBillingProjectRecord(newProjectName),
       freshBillingProjectRecord(newProjectName2)
     )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
@@ -70,7 +70,7 @@ class BillingProjectComponentSpec extends TestComponent with FlatSpecLike with C
 
   it should "save a new project with its ActiveOperationRecord" in isolatedDbTest {
     val newOpRecord = freshOpRecord(newProjectName)
-    dbFutureValue { _.billingProjectQuery.saveNewProject(newProjectName, newOpRecord) } shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, newOpRecord) shouldEqual newProjectName
     dbFutureValue { _.operationQuery.getOperations(newProjectName) } shouldEqual Seq(newOpRecord)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/TestComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/TestComponent.scala
@@ -3,6 +3,8 @@ package org.broadinstitute.dsde.workbench.gpalloc.db
 import akka.actor.{Actor, ActorContext, ActorSystem, Props}
 import akka.testkit.TestActorRef
 import org.broadinstitute.dsde.workbench.gpalloc.TestExecutionContext
+import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
+import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus.BillingProjectStatus
 import org.broadinstitute.dsde.workbench.gpalloc.util.Throttler
 import org.scalatest.Matchers
 import org.scalatest.concurrent.ScalaFutures
@@ -32,6 +34,15 @@ trait TestComponent extends Matchers with ScalaFutures
       case t: Throwable => t.printStackTrace(); throw t
     } finally {
       dbFutureValue { _ => DbSingleton.ref.dataAccess.truncateAll() }
+    }
+  }
+
+  // populate a new project and some records
+  def saveProjectAndOps(billingProject: String, operationRecord: ActiveOperationRecord, status: BillingProjectStatus = BillingProjectStatus.CreatingProject): String = {
+    dbFutureValue { da =>
+      DBIO.seq(
+        da.billingProjectQuery.saveNew(billingProject, status),
+        da.operationQuery.saveNewOperations(Seq(operationRecord))) map { _ => billingProject }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
@@ -100,11 +100,12 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
   }
 
   it should "throttle project creation" in isolatedDbTest {
-    val mockGoogleDAO = new MockGoogleDAO()
+    val mockGoogleDAO = new MockGoogleDAO(operationsDoneYet = false)
     withSupervisor(mockGoogleDAO) { supervisor =>
 
       //kick off two project creates. the throttle should kick in
       supervisor ! RequestNewProject(newProjectName)
+      Thread.sleep(100) //make sure the messages are delivered in order
       supervisor ! RequestNewProject(newProjectName2)
 
       eventually(timeout = Timeout(Span(2, Seconds))) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/monitor/ProjectMonitoringSpec.scala
@@ -107,6 +107,11 @@ class ProjectMonitoringSpec extends TestKit(ActorSystem("gpalloctest")) with Tes
       supervisor ! RequestNewProject(newProjectName)
       supervisor ! RequestNewProject(newProjectName2)
 
+      eventually(timeout = Timeout(Span(2, Seconds))) {
+        dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName) }.get.status shouldBe CreatingProject
+        dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName2) }.get.status shouldBe Queued
+      }
+
       eventually(timeout = Timeout(Span(4, Seconds))) {
         supervisor.underlyingActor.projectCreationTimes.length shouldBe 2
         val second = supervisor.underlyingActor.projectCreationTimes(1)


### PR DESCRIPTION
Previously, project creation requests were going into the throttle but not into the database. This made it impossible to tell how many projects were somewhere in the works.

Improvement: the supervisor now saves projects into the db as soon as it gets a request with the new status Queued. As before, CreatingProject means the project has started creation in Google land.