### PR TITLE
Bump project minimums

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -2,8 +2,8 @@ gpalloc {
   projectMonitorPollInterval = 5 seconds
   abandonmentTime = 2 hours
   abandonmentSweepInterval = 10 minutes
-  minimumFreeProjects = 25
-  minimumProjects = 100
+  minimumFreeProjects = 100
+  minimumProjects = 500
 
   #GCP quota is one CreateProject operation per second.
   #https://cloud.google.com/resource-manager/docs/limits


### PR DESCRIPTION
I keep hearing that tests failed because GPA ran out of projects. There's ~160 projects in the pool in gpalloc-qa, so from tests that Gary and I did that means that 5+ test suites would need to be running at once in order to exhaust the pool. This seems... plausible?

This PR bumps the number of projects in the pool to 500, and the threshold for creating new projects to be 100 -- i.e. if there are fewer than 100 free projects in the pool it'll start creating more.