### PR TITLE
[QA-723] Assign projects that have not been recently assigned first

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
@@ -172,8 +172,8 @@ trait BillingProjectComponent extends GPAllocComponent {
     def releaseProject(billingProject: String): DBIO[Int] = {
       findBillingProject(billingProject)
         .filter(_.status === BillingProjectStatus.Assigned.toString)
-        .map(bp => (bp.owner, bp.status, bp.lastAssignedTime))
-        .update(None, BillingProjectStatus.Unassigned.toString, BillingProjectRecord.tsToDB(None))
+        .map(bp => (bp.owner, bp.status))
+        .update(None, BillingProjectStatus.Unassigned.toString)
     }
 
     //Entirely forgets that this project ever existed.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponent.scala
@@ -134,7 +134,7 @@ trait BillingProjectComponent extends GPAllocComponent {
       */
     def assignProjectFromPool(owner: String): DBIO[Option[String]] = {
       //query for a billing project that's free
-      val freeBillingProject = findUnassignedProjects.take(1).forUpdate
+      val freeBillingProject = findUnassignedProjects.sortBy(_.lastAssignedTime.asc).take(1).forUpdate
 
       //update it to be assigned to this owner
       freeBillingProject.result flatMap { bps: Seq[BillingProjectRecord] =>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
@@ -79,9 +79,11 @@ class BillingProjectComponentSpec extends TestComponent with FlatSpecLike with C
     dbFutureValue { _.billingProjectQuery.saveNew(newProjectName2, BillingProjectStatus.CreatingProject) } shouldEqual newProjectName2
 
     dbFutureValue { _.billingProjectQuery.assignProjectFromPool(requestingUser) } shouldEqual Some(newProjectName)
+    // lastAssignedTime should not reset when a project is released
+    val lastAssigned = dbFutureValue( _.billingProjectQuery.getBillingProject(newProjectName)).map(_.lastAssignedTime)
     dbFutureValue { _.billingProjectQuery.releaseProject(newProjectName) } shouldEqual 1
 
-    dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName) } shouldEqual Some(BillingProjectRecord(newProjectName, None, BillingProjectStatus.Unassigned, None))
+    dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName) } shouldEqual Some(BillingProjectRecord(newProjectName, None, BillingProjectStatus.Unassigned, lastAssigned))
 
     //ensure the other one wasn't harmed
     dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName2) } shouldEqual Some(BillingProjectRecord(newProjectName2, None, BillingProjectStatus.CreatingProject, None))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/db/BillingProjectComponentSpec.scala
@@ -80,7 +80,7 @@ class BillingProjectComponentSpec extends TestComponent with FlatSpecLike with C
 
     dbFutureValue { _.billingProjectQuery.assignProjectFromPool(requestingUser) } shouldEqual Some(newProjectName)
     // lastAssignedTime should not reset when a project is released
-    val lastAssigned = dbFutureValue( _.billingProjectQuery.getBillingProject(newProjectName)).map(_.lastAssignedTime)
+    val lastAssigned = dbFutureValue( _.billingProjectQuery.getBillingProject(newProjectName)).flatMap(_.lastAssignedTime)
     dbFutureValue { _.billingProjectQuery.releaseProject(newProjectName) } shouldEqual 1
 
     dbFutureValue { _.billingProjectQuery.getBillingProject(newProjectName) } shouldEqual Some(BillingProjectRecord(newProjectName, None, BillingProjectStatus.Unassigned, lastAssigned))


### PR DESCRIPTION
In an effort to increase time between usage of Google projects, this PR should now assign projects based on when they were last assigned. 