### PR TITLE
[QA-723] delete projects when they have more pets than defined threshold

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,6 +16,10 @@ gpalloc {
   #https://cloud.google.com/service-management/quotas
   opsThrottle = 15
   opsThrottlePerDuration = 10 seconds
+
+  # GCP quota for service accounts is 100. We delete any projects that have more than 90 pets to avoid this quota
+  # https://cloud.google.com/iam/quotas#quotas
+  maxPets = 90
 }
 
 deploymentManager {

--- a/src/main/scala/examples/TestGoogle.scala
+++ b/src/main/scala/examples/TestGoogle.scala
@@ -52,7 +52,8 @@ object TestGoogle extends App {
       dmConfig.getBoolean("cleanupDeploymentAfterCreating"),
       dmConfig.getString("requesterPaysRole"), //organizations/{{$orgId}}/roles/RequesterPays
       gpAllocConfig.opsThrottle,
-      gpAllocConfig.opsThrottlePerDuration)
+      gpAllocConfig.opsThrottlePerDuration,
+      gpAllocConfig.maxPets)
 
     val projectName = "gpalloc-dev-develop-sywr9jt"
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/Boot.scala
@@ -49,7 +49,8 @@ object Boot extends App with LazyLogging {
       dmConfig.cleanupDeploymentAfterCreating,
       dmConfig.requesterPaysRole,
       gpAllocConfig.opsThrottle,
-      gpAllocConfig.opsThrottlePerDuration)
+      gpAllocConfig.opsThrottlePerDuration,
+      gpAllocConfig.maxPets)
 
     val projectCreationSupervisor = system.actorOf(
       ProjectCreationSupervisor.props(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/GPAllocConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/GPAllocConfig.scala
@@ -13,5 +13,6 @@ case class GPAllocConfig(
                           projectsThrottlePerDuration: FiniteDuration,
                           opsThrottle: Int,
                           opsThrottlePerDuration: FiniteDuration,
-                          projectPrefix: String
+                          projectPrefix: String,
+                          maxPets: Int
                         )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/config.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/config/config.scala
@@ -28,7 +28,8 @@ package object config {
       config.as[FiniteDuration]("projectsThrottlePerDuration"),
       config.as[Int]("opsThrottle"),
       config.as[FiniteDuration]("opsThrottlePerDuration"),
-      config.as[String]("projectPrefix")
+      config.as[String]("projectPrefix"),
+      config.as[Int]("maxPets")
     )
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/dao/GoogleDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/dao/GoogleDAO.scala
@@ -10,6 +10,8 @@ abstract class GoogleDAO {
   def transferProjectOwnership(project: String, owner: String): Future[AssignedProject]
   def scrubBillingProject(projectName: String): Future[Unit]
 
+  def overPetLimit(projectName: String): Future[Boolean]
+
   def createProject(projectName: String, billingAccountId: String): Future[ActiveOperationRecord]
   def pollOperation(operation: ActiveOperationRecord): Future[ActiveOperationRecord]
   def cleanupDeployment(projectName: String): Future[Unit]

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -24,6 +24,10 @@ gpalloc {
   #https://cloud.google.com/service-management/quotas
   opsThrottle = 15
   opsThrottlePerDuration = 10 seconds
+
+  # GCP quota for service accounts is 100. We delete any projects that have more than 90 pets to avoid this quota
+  # https://cloud.google.com/iam/quotas#quotas
+  maxPets = 90
 }
 
 mysql {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -283,8 +283,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   it should "delete projects with too many pets when they are forcefully cleaned up" in isolatedDbTest {
     val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 0, googleDAO = new TooManyPetsGoogleDAO(Set(newProjectName2)))
     saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
-    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) shouldEqual newProjectName2
-    dbFutureValue { _.billingProjectQuery.assignProjectFromPool(userInfo.userEmail.value) }
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Unassigned) shouldEqual newProjectName2
 
     gpAlloc.forceCleanupAll()
     eventually {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -280,7 +280,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
     dbFutureValue { _.billingProjectQuery.listEverything() } shouldEqual Seq()
   }
 
-  it should "delete projects with too many pets when they are forcefully cleaned up" in {
+  it should "delete projects with too many pets when they are forcefully cleaned up" in isolatedDbTest {
     val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 0, googleDAO = new TooManyPetsGoogleDAO(Set(newProjectName2)))
     saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
     saveProjectAndOps(newProjectName, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) shouldEqual newProjectName2

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -5,27 +5,27 @@ import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import org.broadinstitute.dsde.workbench.gpalloc.dao.MockGoogleDAO
 import org.broadinstitute.dsde.workbench.gpalloc.db.{BillingProjectRecord, DbReference, DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
-import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.{RequestNewProject, RegisterGPAllocService}
+import org.broadinstitute.dsde.workbench.gpalloc.monitor.ProjectCreationSupervisor.{RegisterGPAllocService, RequestNewProject}
 import org.broadinstitute.dsde.workbench.gpalloc.service.{GPAllocService, GoogleProjectNotFound, NoGoogleProjectAvailable, NotYourGoogleProject}
 import org.broadinstitute.dsde.workbench.util.NoopActor
 import org.scalatest.FlatSpecLike
 import org.scalatest.concurrent.Eventually._
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestComponent with FlatSpecLike with CommonTestData { testKit =>
   import profile.api._
 
   //returns a service and a probe that watches the pretend supervisor actor
-  def gpAllocService(dbRef: DbReference, minimumFreeProjects: Int, abandonmentTime: FiniteDuration = 20 hours, minimumProjects: Int = 0): (GPAllocService, TestProbe, MockGoogleDAO) = {
-    val mockGoogleDAO = new MockGoogleDAO()
+  def gpAllocService(dbRef: DbReference, minimumFreeProjects: Int, abandonmentTime: FiniteDuration = 20 hours, minimumProjects: Int = 0, googleDAO: MockGoogleDAO = new MockGoogleDAO()): (GPAllocService, TestProbe, MockGoogleDAO) = {
     val probe = TestProbe()
     val noopActor = probe.childActorOf(NoopActor.props)
     testKit watch noopActor
     val newConf = gpAllocConfig.copy(minimumFreeProjects=minimumFreeProjects, minimumProjects=minimumProjects, abandonmentTime=abandonmentTime)
-    val gpAlloc = new GPAllocService(dbRef, swaggerConfig, probe.ref, mockGoogleDAO, newConf)
+    val gpAlloc = new GPAllocService(dbRef, swaggerConfig, probe.ref, googleDAO, newConf)
     probe.expectMsgClass(1 seconds, classOf[RegisterGPAllocService])
-    (gpAlloc, probe, mockGoogleDAO)
+    (gpAlloc, probe, googleDAO)
   }
 
   "GPAllocService" should "request an existing google project" in isolatedDbTest {
@@ -256,5 +256,40 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
     }
     dbFutureValue { _.billingProjectQuery.listEverything() } shouldEqual Seq()
 
+  }
+
+  class TooManyPetsGoogleDAO(exemptProjects: Set[String] = Set.empty) extends MockGoogleDAO {
+    override def overPetLimit(projectName: String): Future[Boolean] = {
+      if (exemptProjects.contains(projectName)) {
+        Future.successful(false)
+      } else {
+        Future.successful(true)
+      }
+    }
+  }
+
+  it should "delete projects that have too many pets when they are released" in isolatedDbTest {
+    val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 0, googleDAO = new TooManyPetsGoogleDAO)
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    dbFutureValue { _.billingProjectQuery.assignProjectFromPool(userInfo.userEmail.value) }
+
+    gpAlloc.releaseGoogleProject(userInfo.userEmail, newProjectName).futureValue
+    eventually {
+      mockGoogleDAO.deletedProjects shouldBe Set(newProjectName)
+    }
+    dbFutureValue { _.billingProjectQuery.listEverything() } shouldEqual Seq()
+  }
+
+  it should "delete projects with too many pets when they are forcefully cleaned up" in {
+    val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 0, googleDAO = new TooManyPetsGoogleDAO(Set(newProjectName2)))
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) shouldEqual newProjectName2
+    dbFutureValue { _.billingProjectQuery.assignProjectFromPool(userInfo.userEmail.value) }
+
+    gpAlloc.forceCleanupAll()
+    eventually {
+      mockGoogleDAO.deletedProjects shouldBe Set(newProjectName)
+    }
+    dbFutureValue { _.billingProjectQuery.listEverything() } shouldEqual Seq()
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -288,7 +288,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
     gpAlloc.forceCleanupAll()
     eventually {
       mockGoogleDAO.deletedProjects shouldBe Set(newProjectName)
+      mockGoogleDAO.scrubbedProjects shouldBe Set(newProjectName2)
     }
-    dbFutureValue { _.billingProjectQuery.listEverything() } shouldEqual Seq()
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -283,7 +283,7 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
   it should "delete projects with too many pets when they are forcefully cleaned up" in isolatedDbTest {
     val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 0, googleDAO = new TooManyPetsGoogleDAO(Set(newProjectName2)))
     saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
-    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) shouldEqual newProjectName2
+    saveProjectAndOps(newProjectName2, freshOpRecord(newProjectName2), BillingProjectStatus.Assigned) shouldEqual newProjectName2
     dbFutureValue { _.billingProjectQuery.assignProjectFromPool(userInfo.userEmail.value) }
 
     gpAlloc.forceCleanupAll()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/dao/MockGoogleDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/dao/MockGoogleDAO.scala
@@ -50,4 +50,6 @@ class MockGoogleDAO(operationsReturnError: Boolean = false, operationsDoneYet: B
     deletedProjects += projectName
     Future.successful(())
   }
+
+  override def overPetLimit(projectName: String): Future[Boolean] = Future.successful(false)
 }


### PR DESCRIPTION
Deleting and re-creating pets in projects during integration tests runs causes problems. To address this, we will stop deleting pets when a project is released or otherwise cleaned up. To prevent projects from hitting the 100 SA/project GCP quota, we will also delete projects in the pool when they end up with more than 90 SAs (which we can modify if we hit the quota as I'm not sure how many SAs a test run creates in a project). 