### PR TITLE
IA-2041 Remove ICMP traffic open to the world in Terra billing projects

### DIFF
--- a/configs/gpalloc.conf.ctmpl
+++ b/configs/gpalloc.conf.ctmpl
@@ -22,7 +22,7 @@ deploymentManager {
     # We typically use GitHub here. In this case, make sure of two things:
 	#    1. The URL you put here is the raw text version of the template, not GitHub's HTML preview of the page. You'll know it's right if the URL starts "https://raw.githubusercontent.com". GPAlloc sanity checks this and will fail to start up if you get it wrong.
 	#    2. Don't refer to the file via a GitHub branch. This URL will point to the most recent version of the file on that branch, which means the template could change underneath you. This is really bad because it means we can't track which template we used to create any given project. Instead, refer to it through a specific commit, which is immutable. The only exception to this is if you're running on a FiaB and developing the DM template, in which case doing this deliberately will spare you repeatedly changing the Rawls config and redeploying for new versions. To combat getting this wrong, GPAlloc checks for "master" and "develop" branches in the URL and will fail to start up if they're present.
-    templatePath = "https://raw.githubusercontent.com/broadinstitute/gcp-dm-templates/637f400d758c3a7fa1f3a0b1ca2e207533787c2f/firecloud_project.py"
+    templatePath = "https://raw.githubusercontent.com/broadinstitute/gcp-dm-templates/eeee90fa4619b273d07206a867b01914cdeb0a30/firecloud_project.py"
     projectID = "terra-deployments-{{$environment}}"
     orgID = {{$orgId}}
     billingProbeEmail = "billingprobe@terra-deployments-{{$environment}}.iam.gserviceaccount.com"


### PR DESCRIPTION
Context:
https://broadworkbench.atlassian.net/browse/IA-2041
broadinstitute/gcp-dm-templates#24
https://github.com/broadinstitute/firecloud-develop/pull/2234

This new template does not create an open-to-the-world ICMP firewall rule in high-security Terra billing projects.