### PR TITLE
[IA-2135] Add GKE cluster cleanup

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,6 +63,7 @@ object Dependencies {
   val liquibase: ModuleID = "org.liquibase"       % "liquibase-core"        % "3.5.3"
 
   val googleBilling: ModuleID = "com.google.apis" % "google-api-services-cloudbilling" % "v1-rev16-1.23.0" excludeAll(excludeGuavaJDK5)
+  val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20200805-1.30.10"
   val googleDataproc: ModuleID =    "com.google.apis"     % "google-api-services-dataproc" % s"v1-rev91-$googleV" excludeAll(excludeGuavaJDK5, excludeJacksonCore, excludeFindbugsJsr, excludeHttpComponent)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20181207-1.28.0")
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.5.0"
@@ -102,6 +103,7 @@ object Dependencies {
     workbenchMetrics,
 
     googleBilling,
+    googleContainerV1,
     googleDataproc,
     googleDeploymentManager,
     googleRpc,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/dao/HttpGoogleBillingDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/dao/HttpGoogleBillingDAO.scala
@@ -502,7 +502,7 @@ class HttpGoogleBillingDAO(appName: String,
       _ <- sequentially(gkeClusters) { gkeCluster =>
         val nameString =
           s"projects/${projectName}/locations/${gkeCluster.getLocation}/clusters/${gkeCluster.getName}"
-        logger info s"cluster name string: ${nameString}"
+        logger debug s"GKE cluster name string: ${nameString}"
         googleRq(
           gke
             .projects()


### PR DESCRIPTION
Adds GKE cluster cleanup to `HttpGoogleBillingDAO` since IA team is planning on creating gke clusters in automation tests to test out the Galaxy integration