### PR TITLE
[QA-1507] Tolerate 404 from Google when listing project SAs

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/service/GPAllocService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/gpalloc/service/GPAllocService.scala
@@ -136,7 +136,7 @@ class GPAllocService(protected val dbRef: DbReference,
   private def overPetLimitOrProjectDeleted(project: String): Future[Boolean] = {
     googleBillingDAO.overPetLimit(project).recover {
       case t: GoogleJsonResponseException if t.getStatusCode == 404 => {
-        logger.info(s"Could not locate $project in Google, removing it from database")
+        logger.info(s"Could not locate $project in Google, it should be nuked")
         true
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/gpalloc/GPAllocServiceSpec.scala
@@ -2,6 +2,9 @@ package org.broadinstitute.dsde.workbench.gpalloc
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.HttpResponseException.Builder
 import org.broadinstitute.dsde.workbench.gpalloc.dao.MockGoogleDAO
 import org.broadinstitute.dsde.workbench.gpalloc.db.{BillingProjectRecord, DbReference, DbSingleton, TestComponent}
 import org.broadinstitute.dsde.workbench.gpalloc.model.BillingProjectStatus
@@ -289,6 +292,22 @@ class GPAllocServiceSpec extends TestKit(ActorSystem("gpalloctest")) with TestCo
     eventually {
       mockGoogleDAO.deletedProjects shouldBe Set(newProjectName)
       mockGoogleDAO.scrubbedProjects shouldBe Set(newProjectName2)
+    }
+  }
+
+  it should "tolerate releasing a project that has been deleted in Google" in isolatedDbTest {
+    class NonExistentProject() extends MockGoogleDAO {
+      override def overPetLimit(projectName: String): Future[Boolean] = {
+        Future.failed(new GoogleJsonResponseException(new Builder(404, "project not found", new HttpHeaders()), null))
+      }
+    }
+
+    val (gpAlloc, _, mockGoogleDAO) = gpAllocService(dbRef, 0, googleDAO = new NonExistentProject())
+    saveProjectAndOps(newProjectName, freshOpRecord(newProjectName), BillingProjectStatus.Unassigned) shouldEqual newProjectName
+
+    gpAlloc.forceCleanupAll()
+    eventually {
+      mockGoogleDAO.deletedProjects shouldBe Set(newProjectName)
     }
   }
 }


### PR DESCRIPTION
Ticket: [QA-1507](https://broadworkbench.atlassian.net/browse/QA-1507)
When Google returns 404 while listing the service accounts in a project, just nuke the project from gpalloc's database since it either doesn't exist or gpalloc has somehow lost access to it